### PR TITLE
Add missing define constraint to KAG50 add-on editor assembly definition

### DIFF
--- a/AddOns/KAG50/Editor/Latios.Kinemation.Graph.Editor.asmdef
+++ b/AddOns/KAG50/Editor/Latios.Kinemation.Graph.Editor.asmdef
@@ -22,7 +22,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "LATIOS_ADDON_KAG50"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Adding a missing LATIOS_ADDON_KAG50 define in the KAG50 add-on Editor assembly that is causing exceptions when the define is missing.
