### PR TITLE
Bake transitions between states

### DIFF
--- a/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
+++ b/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
@@ -4,6 +4,7 @@ using Latios.Kinemation;
 using Latios.Kinemation.Authoring;
 using Unity.Collections;
 using Unity.Entities;
+using UnityEditor.Animations;
 using UnityEngine;
 
 namespace Latios.MecanimV2.Authoring
@@ -76,11 +77,23 @@ namespace Latios.MecanimV2.Authoring
             // Bake avatar masks
             var avatarMasks = new NativeList<UnityObjectRef<AvatarMask>>(1,Allocator.Temp);
             var layers = baseAnimatorControllerRef.controller.layers;
+            
             foreach (var layer in layers)
             {
                 if (layer.avatarMask == null) continue;
                 
                 avatarMasks.Add(layer.avatarMask);
+            }
+            
+            // Add build buffer element for layer weights if there is more than one layer
+            if (layers.Length > 1)
+            {
+                DynamicBuffer<LayerWeights> weights = baker.AddBuffer<LayerWeights>(entity);
+
+                foreach (var layer in layers)
+                {
+                    weights.Add(new LayerWeights { weight = layer.defaultWeight });
+                }
             }
 
             m_clipSetBlobHandle    = baker.RequestCreateBlobAsset(authoring, skeletonClipConfigs);

--- a/AddOns/MecanimV2/Components/ControllerBlobs.cs
+++ b/AddOns/MecanimV2/Components/ControllerBlobs.cs
@@ -232,14 +232,14 @@ namespace Latios.MecanimV2
             // with parent sub-state machine indices. Each state would then index a sub-state machine and we'd walk back to the root.
             // Such a strategy would still support our flattened representation.
             public BlobArray<Transition> anyStateTransitions;
+            
             // These only have destination state indices and conditions. There's no timing. And we only care about this on the very first update.
-            // In baking, we need to identify the default transition and ensure that is index 0.
+            // In baking, we need to identify the default transition and add it at the end, after all other entry transitions.
             // Also in baking, we should convert each state -> exit -> entry -> state permutation to direct state -> state transitions.
             // This might sound like a potential issue of overflowing 15 bits, but we have a unique set of transition indices per state.
             // Without this flattening, we run into issues with our transition data being spread across two different transition instances.
             // The exit transition (or transition into a sub-state machine) contains the blending info and interrupts, while the entry
             // transition contains the target state.
-
             public BlobArray<Transition>          initializationEntryStateTransitions;
             public BlobArray<int>                 stateNameHashes;
             public BlobArray<int>                 stateNameEditorHashes;

--- a/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
+++ b/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
@@ -261,24 +261,20 @@ namespace Latios.MecanimV2.Authoring.Systems
 
             bool addDefaultState = mustAddDefaultStateTransition && layer.stateMachine.defaultState != null;
             
-            if (addDefaultState)
-            {
-                transitionsCount++; // we allocate one more for the default entry state transition in position 0 when needed
-            }
+            if (addDefaultState) transitionsCount++; // we allocate one more for the default entry state transition in position 0 when needed
             
             BlobBuilderArray<MecanimControllerBlob.Transition> entryTransitionsBuilder = builder.Allocate(ref transitionsBlobArray, transitionsCount); 
-
-            if (addDefaultState)
-            {
-                // Add a dummy transition to the default state in position 0 of the array
-                entryTransitionsBuilder[0].destinationStateIndex = (short) statesIndicesHashMap[layer.stateMachine.defaultState];
-            }
-
+            
             for (var i = 0; i < collapsedTransitions.Count; i++)
             {
                 var collapsedTransition = collapsedTransitions[i];
-                int indexInBlobArray = addDefaultState ? i + 1 : i;
-                BakeAnimatorStateTransitionWithCustomConditions(ref builder, ref entryTransitionsBuilder[indexInBlobArray], collapsedTransition.transition, collapsedTransition.conditions, collapsedTransition.destinationStateIndex, parameters);
+                BakeAnimatorStateTransitionWithCustomConditions(ref builder, ref entryTransitionsBuilder[i], collapsedTransition.transition, collapsedTransition.conditions, collapsedTransition.destinationStateIndex, parameters);
+            }
+            
+            if (addDefaultState)
+            {
+                // Add a dummy transition to the default state in the last position of the blob array
+                entryTransitionsBuilder[collapsedTransitions.Count].destinationStateIndex = (short) statesIndicesHashMap[layer.stateMachine.defaultState];
             }
         }
 

--- a/AddOns/MecanimV2/Utilities/StateMachineEvaluation.cs
+++ b/AddOns/MecanimV2/Utilities/StateMachineEvaluation.cs
@@ -186,14 +186,14 @@ namespace Latios.MecanimV2
             public float duration;
         }
 
-        static MecanimStateMachineActiveStates SetupInitialState(ref Blob controllerBlob,
+        public static MecanimStateMachineActiveStates SetupInitialState(ref Blob controllerBlob,
                                                                  int stateMachineIndex,
                                                                  ReadOnlySpan<MecanimParameter> parameters,
                                                                  Span<BitField64>               triggersToReset)
         {
             ref var stateMachine = ref controllerBlob.stateMachines[stateMachineIndex];
             ref var candidates   = ref stateMachine.initializationEntryStateTransitions;
-            for (int i = 1; i < candidates.Length; i++)
+            for (int i = 0; i < candidates.Length; i++)
             {
                 ref var candidate = ref candidates[i];
                 if (MatchesConditions(ref candidate.conditions, ref controllerBlob.parameterTypes, parameters, triggersToReset))


### PR DESCRIPTION
Add baking for transitions coming out of each state and their lists of conditions.
We are flattening all sub state machines, so this change recursively finds the final state for each transaction, collecting their conditions along the way. 
Once the algorithm reaches a specific state (and not another state machine or Exit state), it saves the transaction information using the settings from the initial transition, the final state index it found, and all the conditions it found in any transitions used to reach the final destination state.
When exit states are reached, we iterate through all the transitions coming out of that state machine in the parent state machine. If it's a root state machine, we combine transitions that are exiting the state machine with all the entry transitions for the root state machine (including the default state transition).

