### PR TITLE
Mecanim v2 usage

### DIFF
--- a/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
+++ b/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
@@ -74,15 +74,23 @@ namespace Latios.MecanimV2.Authoring
                 parametersBuffer.Add(parameterData);
             }
             
-            // Bake avatar masks
-            var avatarMasks = new NativeList<UnityObjectRef<AvatarMask>>(1,Allocator.Temp);
+            // Bake avatar masks and create StateMachines states buffer
             var layers = baseAnimatorControllerRef.controller.layers;
+            
+            var avatarMasks = new NativeList<UnityObjectRef<AvatarMask>>(1,Allocator.Temp);
+            var statesBuffer = baker.AddBuffer<MecanimStateMachineActiveStates>(entity);
             
             foreach (var layer in layers)
             {
-                if (layer.avatarMask == null) continue;
-                
-                avatarMasks.Add(layer.avatarMask);
+                if (layer.avatarMask != null)
+                {
+                    avatarMasks.Add(layer.avatarMask);
+                }
+
+                if (layer.syncedLayerIndex == -1)
+                {
+                    statesBuffer.Add(MecanimStateMachineActiveStates.CreateInitialState());
+                }
             }
             
             // Add build buffer element for layer weights if there is more than one layer
@@ -90,9 +98,10 @@ namespace Latios.MecanimV2.Authoring
             {
                 DynamicBuffer<LayerWeights> weights = baker.AddBuffer<LayerWeights>(entity);
 
-                foreach (var layer in layers)
+                for (var index = 0; index < layers.Length; index++)
                 {
-                    weights.Add(new LayerWeights { weight = layer.defaultWeight });
+                    var layer = layers[index];
+                    weights.Add(new LayerWeights { weight = index == 0 ? 1 : layer.defaultWeight });
                 }
             }
 

--- a/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
+++ b/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
@@ -716,8 +716,8 @@ namespace Latios.MecanimV2.Authoring.Systems
                 // See https://runevision.com/thesis/rune_skovbo_johansen_thesis.pdf at 6.3 (p58) for details.
                 // Because atan2 is expensive at runtime for FreeformDirectional2D, and we need to do it with O(n^2) complexity,
                 // we precompute the results in the blob.
-                var pipjBuilder = builder.Allocate(ref blendTreeBlob.pipjs, (childrenBuilder.Length - 1) * (childrenBuilder.Length - 1));
-                for (int i = 0; i < childCount; i++)
+                var pipjBuilder = builder.Allocate(ref blendTreeBlob.pipjs, childrenBuilder.Length * (childrenBuilder.Length - 1));
+                for (int i = 0; i < childCount - 1; i++)
                 {
                     var pi    = childrenBuilder[i].position;
                     var pimag = math.length(pi);

--- a/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
+++ b/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
@@ -864,16 +864,17 @@ namespace Latios.MecanimV2.Authoring.Systems
                     continue;
 
                 int influencingLayersCount = layersInfluencingTimingsByAffectedLayer.CountValuesForKey(i);
-                if (influencingLayersCount == 0)
-                    continue;
 
                 // Get associated state machine blob
-                ref var stateMachineBlob = ref stateMachinesBuilder[owningLayerToStateMachine[i]];
+                var stateMachineForThisLayer = owningLayerToStateMachine[i];
+                ref var stateMachineBlob = ref stateMachinesBuilder[stateMachineForThisLayer];
 
                 // initialize the blob array for layers affecting timings on the state machine blob
-                BlobBuilderArray<short> influencingLayersBuilder = builder.Allocate(ref stateMachineBlob.influencingLayers, influencingLayersCount);
+                BlobBuilderArray<short> influencingLayersBuilder = builder.Allocate(ref stateMachineBlob.influencingLayers, influencingLayersCount + 1);
 
-                var indexInArrayOfInfluencingLayers = 0;
+                influencingLayersBuilder[0] = i;
+                
+                var indexInArrayOfInfluencingLayers = 1;
                 if (layersInfluencingTimingsByAffectedLayer.TryGetFirstValue(i, out short influencingLayer, out NativeParallelMultiHashMapIterator<short> it))
                 {
                     do
@@ -884,8 +885,9 @@ namespace Latios.MecanimV2.Authoring.Systems
                     while (layersInfluencingTimingsByAffectedLayer.TryGetNextValue(out influencingLayer, ref it));
                 }
 
-                stateMachinesBuilder[owningLayerToStateMachine[i]] = stateMachineBlob;
-                NativeSortExtension.Sort((short*)stateMachinesBuilder.GetUnsafePtr(), stateMachinesBuilder.Length);
+                NativeSortExtension.Sort((short*)influencingLayersBuilder.GetUnsafePtr(), influencingLayersBuilder.Length);
+                
+                stateMachinesBuilder[stateMachineForThisLayer] = stateMachineBlob;
             }
         }
 

--- a/AddOns/MecanimV2/Systems/UpdateMecanimSystem.cs
+++ b/AddOns/MecanimV2/Systems/UpdateMecanimSystem.cs
@@ -42,7 +42,7 @@ namespace Latios.Mecanim.AddOns.MecanimV2.Systems
 
             public void Execute(ref MecanimController mecanimController, DynamicBuffer<MecanimStateMachineActiveStates> stateMachineActiveStates, DynamicBuffer<LayerWeights> layerWeights, DynamicBuffer<MecanimParameter> parameters)
             {
-                Span<BitField64> localTriggersToReset = stackalloc BitField64[parameters.Length / 64 + 1];
+                Span<BitField64> localTriggersToReset = stackalloc BitField64[1 + ((parameters.Length-1) >> 6)];
                 Span<StateMachineEvaluation.StatePassage> statePassages = stackalloc StateMachineEvaluation.StatePassage[8];
                 
                 for (var i = 0; i < stateMachineActiveStates.Length; i++)

--- a/AddOns/MecanimV2/Systems/UpdateMecanimSystem.cs
+++ b/AddOns/MecanimV2/Systems/UpdateMecanimSystem.cs
@@ -1,33 +1,71 @@
-using Latios;
+using System;
+using Latios.MecanimV2;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
-using Unity.Jobs;
-using Unity.Mathematics;
-using Latios.Transforms;
 
-namespace Latios.Mecanim
+namespace Latios.Mecanim.AddOns.MecanimV2.Systems
 {
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [RequireMatchingQueriesForUpdate]
+    [DisableAutoCreation]
     [BurstCompile]
     public partial struct UpdateMecanimSystem : ISystem
     {
-        LatiosWorldUnmanaged latiosWorld;
-
+        private EntityQuery _mecanimQuery;
+        
         [BurstCompile]
         public void OnCreate(ref SystemState state)
         {
-            latiosWorld = state.GetLatiosWorldUnmanaged();
-        }
-
-        [BurstCompile]
-        public void OnDestroy(ref SystemState state)
-        {
+            _mecanimQuery = state.Fluent()
+                .With<MecanimController>(false)
+                .With<MecanimStateMachineActiveStates>(false)
+                .With<LayerWeights>(true)
+                .With<MecanimParameter>(false).Build();
+            
+            state.RequireForUpdate(_mecanimQuery);
         }
 
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-        
+            state.Dependency = new UpdateStateMachinesJob
+            {
+                DeltaTime = SystemAPI.Time.DeltaTime,
+            }.ScheduleParallel(_mecanimQuery, state.Dependency);
+        }
+
+        [BurstCompile]
+        public partial struct UpdateStateMachinesJob : IJobEntity
+        {
+            public float DeltaTime;
+
+            public void Execute(ref MecanimController mecanimController, DynamicBuffer<MecanimStateMachineActiveStates> stateMachineActiveStates, DynamicBuffer<LayerWeights> layerWeights, DynamicBuffer<MecanimParameter> parameters)
+            {
+                Span<BitField64> localTriggersToReset = stackalloc BitField64[parameters.Length / 64 + 1];
+                Span<StateMachineEvaluation.StatePassage> statePassages = stackalloc StateMachineEvaluation.StatePassage[8];
+                
+                for (var i = 0; i < stateMachineActiveStates.Length; i++)
+                {
+                    var stateMachineActiveState = stateMachineActiveStates[i];
+                    
+                    StateMachineEvaluation.Evaluate(
+                        ref stateMachineActiveState,
+                        ref mecanimController.controllerBlob.Value,
+                        ref mecanimController.skeletonClipsBlob.Value,
+                        i,
+                        DeltaTime,
+                        layerWeights.AsNativeArray().AsReadOnlySpan(),
+                        parameters.AsNativeArray().AsReadOnlySpan(),
+                        localTriggersToReset,
+                        statePassages,
+                        out int passagesCount,
+                        out float newInertialBlendProgressRealtime,
+                        out float newInertialBlendDurationRealtime);
+
+                    stateMachineActiveStates[i] = stateMachineActiveState;
+                }
+            }
         }
     }
 }

--- a/AddOns/MecanimV2/Utilities/MecanimV2Bootstrap.cs
+++ b/AddOns/MecanimV2/Utilities/MecanimV2Bootstrap.cs
@@ -1,3 +1,4 @@
+using Latios.Mecanim.AddOns.MecanimV2.Systems;
 using Unity.Entities;
 
 namespace Latios.MecanimV2
@@ -5,12 +6,12 @@ namespace Latios.MecanimV2
     public static class MecanimV2Bootstrap
     {
         /// <summary>
-        /// Installs the Mecanim state machine runtime systems. This should only be installed in the runtime world.
+        /// Installs the Mecanim v2 state machine runtime systems. This should only be installed in the runtime world.
         /// </summary>
         /// <param name="world"></param>
         public static void InstallMecanimV2Addon(World world)
         {
-            
+            BootstrapTools.InjectSystem(TypeManager.GetSystemTypeIndex<UpdateMecanimSystem>(), world);
         }
     }
 }

--- a/AddOns/MecanimV2/Utilities/MotionEvaluation.cs
+++ b/AddOns/MecanimV2/Utilities/MotionEvaluation.cs
@@ -286,6 +286,9 @@ namespace Latios.MecanimV2
                 // Evaluate weights using dot(pip, pipj)
                 for (int j = 0; j < childCount; j++)
                 {
+                    // TODO: skipping i==j fixes out of range exceptions for now (we don't store pipjs values for i==j in tree.pipjs),
+                    // but might be completely wrong to just skip them.
+                    if (i == j) continue; 
                     var pipj   = tree.pipjs[MecanimControllerBlob.BlendTree.PipjIndex(i, j, childCount)];
                     var h      = math.max(0, 1 - math.dot(pip, pipj.xy) * pipj.z);
                     weights[i] = math.min(weights[i], h);

--- a/AddOns/MecanimV2/Utilities/StateMachineEvaluation.cs
+++ b/AddOns/MecanimV2/Utilities/StateMachineEvaluation.cs
@@ -4,7 +4,6 @@ using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 using Unity.Mathematics;
-
 using Blob = Latios.MecanimV2.MecanimControllerBlob;
 
 namespace Latios.MecanimV2
@@ -56,7 +55,7 @@ namespace Latios.MecanimV2
                                     ref SkeletonClipSetBlob clipsBlob,
                                     int stateMachineIndex,
                                     float scaledDeltaTime,
-                                    ReadOnlySpan<float>                 allLayerWeights,
+                                    ReadOnlySpan<LayerWeights>          allLayerWeights,
                                     ReadOnlySpan<MecanimParameter>      parameters,
                                     Span<BitField64>                    triggersToReset,
                                     Span<StatePassage>                  outputPassages,
@@ -91,7 +90,7 @@ namespace Latios.MecanimV2
                 bool  hasInfluencer   = false;
                 for (int i = stateMachineBlob.influencingLayers[targetIndex]; i >= stateMachineBlob.influencingLayers[0]; i--)
                 {
-                    var weight = allLayerWeights[i];
+                    var weight = allLayerWeights[i].weight;
                     if (i == stateMachineBlob.influencingLayers[targetIndex])
                     {
                         influencingLayerRelativeWeights[targetIndex] = weight * weightRemaining;
@@ -942,7 +941,7 @@ namespace Latios.MecanimV2
                             }
                             break;
                     }
-                    if (index < count)
+                    if (index >= count)
                     {
                         index = -1;
                         arrayIndex++;


### PR DESCRIPTION
- Baking LayerWeights into a DynamicBuffer for runtime modification.
- Fixed influencing layers baking to include the layer that owns the state machine, and sort them.
- Added UpdateMecanimSystem which takes care of updating the states for any entity with proper Mecanim components.
- Added temporary duct-tape fix of skipping i==j iterations in blend tree duration calculations (as we don't store cached values for that), until we figure out what we should be doing in those iterations.
- Switched the `Evaluate` method to receive a `ReadOnlySpan<LayerWeights>` instead of floats, so it matches the way MecanimParameters are passed to the method, and we can just use `layerWeights.AsNativeArray().AsReadOnlySpan()`