### PR TITLE
Public APIs and events buffer structs

### DIFF
--- a/AddOns/MecanimV2/Components/ControllerBlobs.cs
+++ b/AddOns/MecanimV2/Components/ControllerBlobs.cs
@@ -308,6 +308,64 @@ namespace Latios.MecanimV2
 
             internal const float kFreeformDirectionalBias = 2f;
         }
+        
+        
+        internal short GetLayerIndex(FixedString128Bytes layerName)
+        {
+            for (short i = 0; i < layers.Length; i++)
+            {
+                if (layers[i].name.Equals(layerName)) return i;
+            }
+            return -1;
+        }
+        
+        internal short GetStateMachineIndex(FixedString128Bytes layerName)
+        {
+            return layers[GetLayerIndex(layerName)].stateMachineIndex;
+        }
+        
+        internal short GetStateIndex(short stateMachineIndex, FixedString128Bytes fullStateName)
+        {
+            ref var stateMachine = ref stateMachines[stateMachineIndex];
+            
+            for (short i = 0; i < stateMachine.stateNameHashes.Length; i++)
+            {
+                if (fullStateName.Equals(stateMachine.stateNames[i])) return i;
+            }
+            return -1;
+        }
+        
+        internal short GetStateIndex(short stateMachineIndex, int fullStateNameHash)
+        {
+
+            ref var stateMachine = ref stateMachines[stateMachineIndex];
+            
+            for (short i = 0; i < stateMachine.stateNameHashes.Length; i++)
+            {
+                if (fullStateNameHash == stateMachine.stateNameHashes[i]) return i;
+            }
+            return -1;
+        }
+        
+        
+        
+        internal short GetParameterIndex(FixedString128Bytes parameterName)
+        {
+            for (short  i = 0; i < parameterNames.Length; i++)
+            {
+                if (parameterName.Equals(parameterNames[i])) return i;
+            }
+            return -1;
+        }
+        
+        internal short GetParameterIndex(int parameterNameHash)
+        {
+            for (short  i = 0; i < parameterNameHashes.Length; i++)
+            {
+                if (parameterNameHash == parameterNameHashes[i]) return i;
+            }
+            return -1;
+        }
     }
 }
 

--- a/AddOns/MecanimV2/Components/ControllerComponents.cs
+++ b/AddOns/MecanimV2/Components/ControllerComponents.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Latios.Kinemation;
+using Unity.Collections;
 using Unity.Entities;
 
 namespace Latios.MecanimV2
@@ -17,6 +18,46 @@ namespace Latios.MecanimV2
         /// The time since the last inertial blend start, or -1f if no active inertial blending is happening.
         /// </summary>
         public float realtimeInInertialBlend;
+
+        /**
+         * This is an expensive call. Please cache and re-use the result.
+         * fullStateName must include all parent state machines names separated by dots. Example: "MySubMachine.MyChildSubMachine.Jump"
+         */
+        public StateHandle GetStateHandle(FixedString128Bytes layerName, FixedString128Bytes fullStateName)
+        {
+            var stateMachineIndex = controllerBlob.Value.GetStateMachineIndex(layerName);
+            var stateIndex = controllerBlob.Value.GetStateIndex(stateMachineIndex, fullStateName);
+            return new StateHandle { StateMachineIndex = stateMachineIndex, StateIndex = stateIndex };
+        }
+        
+        /**
+         * This is an expensive method. Please cache and re-use the result.
+         * fullStateName must include all parent state machines names separated by dots and be hashed using GetHashCode()
+         * Example: "MySubMachine.MyChildSubMachine.Jump".GetHashCode()
+         */
+        public StateHandle GetStateHandle(FixedString128Bytes layerName, int fullStateNameHashCode)
+        {
+            var stateMachineIndex = controllerBlob.Value.GetStateMachineIndex(layerName);
+            var stateIndex = controllerBlob.Value.GetStateIndex(stateMachineIndex, fullStateNameHashCode);
+            return new StateHandle { StateMachineIndex = stateMachineIndex, StateIndex = stateIndex };
+        }
+        
+        /**
+         * This is an expensive method. Please cache and re-use the result.
+         */
+        public short GetLayerIndex(FixedString128Bytes layerName) => controllerBlob.Value.GetLayerIndex(layerName);
+        
+        /**
+         * This is an expensive method. Please cache and re-use the result.
+         */
+        public short GetParameterIndex(FixedString128Bytes parameterName) => controllerBlob.Value.GetParameterIndex(parameterName);
+        public short GetParameterIndex(int parameterNameHashCode) => controllerBlob.Value.GetParameterIndex(parameterNameHashCode);
+    }
+
+    public struct StateHandle
+    {
+        public short StateMachineIndex;
+        public short StateIndex;
     }
 
     /// <summary>

--- a/AddOns/MecanimV2/Components/EventComponents.cs
+++ b/AddOns/MecanimV2/Components/EventComponents.cs
@@ -1,0 +1,23 @@
+﻿using Unity.Entities;
+
+namespace Latios.MecanimV2
+{
+    public class EventComponents
+    {
+        public struct MecanimClipEvent : IBufferElementData
+        {
+            public int    nameHash;
+            public int    parameter;
+            public double elapsedTime;
+        }
+
+        public struct MecanimStateTransitionEvent : IBufferElementData
+        {
+            public short  stateMachineIndex;
+            public short  currentState;
+            public short  nextState;
+            public bool   completed;
+            public double elapsedTime;
+        }
+    }
+}

--- a/AddOns/MecanimV2/Components/EventComponents.cs.meta
+++ b/AddOns/MecanimV2/Components/EventComponents.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e49b33980db945b99cddab31bae5c4fa
+timeCreated: 1742599753


### PR DESCRIPTION
Adding some methods to the MecanimController to allow users to access:
* Layer indices to update their weights in the layer weights dynamic buffer.
* Parameter indices to update them in the parameters dynamic buffer.
* A StateHandle for a specific state. It contains the corresponding state machine index and state index within that state machine). Can be used in the future for querying for specific MecanimStateTransitionEvent, or anything else that requires identifying a specific state in our blob.