### PR TITLE
Motion evaluation

### DIFF
--- a/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
+++ b/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
@@ -4,7 +4,6 @@ using Latios.Kinemation;
 using Latios.Kinemation.Authoring;
 using Unity.Collections;
 using Unity.Entities;
-using UnityEditor.Animations;
 using UnityEngine;
 
 namespace Latios.MecanimV2.Authoring
@@ -94,15 +93,11 @@ namespace Latios.MecanimV2.Authoring
             }
             
             // Add build buffer element for layer weights if there is more than one layer
-            if (layers.Length > 1)
+            DynamicBuffer<LayerWeights> weights = baker.AddBuffer<LayerWeights>(entity);
+            for (var index = 0; index < layers.Length; index++)
             {
-                DynamicBuffer<LayerWeights> weights = baker.AddBuffer<LayerWeights>(entity);
-
-                for (var index = 0; index < layers.Length; index++)
-                {
-                    var layer = layers[index];
-                    weights.Add(new LayerWeights { weight = index == 0 ? 1 : layer.defaultWeight });
-                }
+                var layer = layers[index];
+                weights.Add(new LayerWeights { weight = index == 0 ? 1 : layer.defaultWeight });
             }
             
             // Add events buffers (for clip events and state transition events)

--- a/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
+++ b/AddOns/MecanimV2/Authoring/AnimatorSmartBaker.cs
@@ -104,6 +104,10 @@ namespace Latios.MecanimV2.Authoring
                     weights.Add(new LayerWeights { weight = index == 0 ? 1 : layer.defaultWeight });
                 }
             }
+            
+            // Add events buffers (for clip events and state transition events)
+            baker.AddBuffer<MecanimClipEvent>(entity);
+            baker.AddBuffer<MecanimStateTransitionEvent>(entity);
 
             m_clipSetBlobHandle    = baker.RequestCreateBlobAsset(authoring, skeletonClipConfigs);
             m_controllerBlobHandle = baker.RequestCreateBlobAsset(baseAnimatorControllerRef.controller);

--- a/AddOns/MecanimV2/Components/ControllerBlobs.cs
+++ b/AddOns/MecanimV2/Components/ControllerBlobs.cs
@@ -337,7 +337,6 @@ namespace Latios.MecanimV2
         
         internal short GetStateIndex(short stateMachineIndex, int fullStateNameHash)
         {
-
             ref var stateMachine = ref stateMachines[stateMachineIndex];
             
             for (short i = 0; i < stateMachine.stateNameHashes.Length; i++)
@@ -349,11 +348,11 @@ namespace Latios.MecanimV2
         
         
         
-        internal short GetParameterIndex(FixedString128Bytes parameterName)
+        internal short GetParameterIndex(FixedString64Bytes parameterName)
         {
-            for (short  i = 0; i < parameterNames.Length; i++)
+            for (short i = 0; i < parameterNames.Length; i++)
             {
-                if (parameterName.Equals(parameterNames[i])) return i;
+                if (parameterName == parameterNames[i]) return i;
             }
             return -1;
         }

--- a/AddOns/MecanimV2/Components/ControllerComponents.cs
+++ b/AddOns/MecanimV2/Components/ControllerComponents.cs
@@ -18,46 +18,6 @@ namespace Latios.MecanimV2
         /// The time since the last inertial blend start, or -1f if no active inertial blending is happening.
         /// </summary>
         public float realtimeInInertialBlend;
-
-        /**
-         * This is an expensive call. Please cache and re-use the result.
-         * fullStateName must include all parent state machines names separated by dots. Example: "MySubMachine.MyChildSubMachine.Jump"
-         */
-        public StateHandle GetStateHandle(FixedString128Bytes layerName, FixedString128Bytes fullStateName)
-        {
-            var stateMachineIndex = controllerBlob.Value.GetStateMachineIndex(layerName);
-            var stateIndex = controllerBlob.Value.GetStateIndex(stateMachineIndex, fullStateName);
-            return new StateHandle { StateMachineIndex = stateMachineIndex, StateIndex = stateIndex };
-        }
-        
-        /**
-         * This is an expensive method. Please cache and re-use the result.
-         * fullStateName must include all parent state machines names separated by dots and be hashed using GetHashCode()
-         * Example: "MySubMachine.MyChildSubMachine.Jump".GetHashCode()
-         */
-        public StateHandle GetStateHandle(FixedString128Bytes layerName, int fullStateNameHashCode)
-        {
-            var stateMachineIndex = controllerBlob.Value.GetStateMachineIndex(layerName);
-            var stateIndex = controllerBlob.Value.GetStateIndex(stateMachineIndex, fullStateNameHashCode);
-            return new StateHandle { StateMachineIndex = stateMachineIndex, StateIndex = stateIndex };
-        }
-        
-        /**
-         * This is an expensive method. Please cache and re-use the result.
-         */
-        public short GetLayerIndex(FixedString128Bytes layerName) => controllerBlob.Value.GetLayerIndex(layerName);
-        
-        /**
-         * This is an expensive method. Please cache and re-use the result.
-         */
-        public short GetParameterIndex(FixedString128Bytes parameterName) => controllerBlob.Value.GetParameterIndex(parameterName);
-        public short GetParameterIndex(int parameterNameHashCode) => controllerBlob.Value.GetParameterIndex(parameterNameHashCode);
-    }
-
-    public struct StateHandle
-    {
-        public short StateMachineIndex;
-        public short StateIndex;
     }
 
     /// <summary>

--- a/AddOns/MecanimV2/Components/EventComponents.cs
+++ b/AddOns/MecanimV2/Components/EventComponents.cs
@@ -2,22 +2,19 @@
 
 namespace Latios.MecanimV2
 {
-    public class EventComponents
+    public struct MecanimClipEvent : IBufferElementData
     {
-        public struct MecanimClipEvent : IBufferElementData
-        {
-            public int    nameHash;
-            public int    parameter;
-            public double elapsedTime;
-        }
+        public int    nameHash;
+        public int    parameter;
+        public double elapsedTime;
+    }
 
-        public struct MecanimStateTransitionEvent : IBufferElementData
-        {
-            public short  stateMachineIndex;
-            public short  currentState;
-            public short  nextState;
-            public bool   completed;
-            public double elapsedTime;
-        }
+    public struct MecanimStateTransitionEvent : IBufferElementData
+    {
+        public short  stateMachineIndex;
+        public short  currentState;
+        public short  nextState;
+        public bool   completed;
+        public double elapsedTime;
     }
 }

--- a/AddOns/MecanimV2/Components/MecanimAspect.cs
+++ b/AddOns/MecanimV2/Components/MecanimAspect.cs
@@ -1,0 +1,403 @@
+﻿using Latios.Kinemation;
+using Latios.Unsafe;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Latios.MecanimV2
+{
+    public readonly partial struct MecanimAspect : IAspect
+    {
+        readonly RefRW<MecanimController>        m_controller;
+        readonly EnabledRefRW<MecanimController> m_controllerEnabled;
+        
+        readonly DynamicBuffer<MecanimStateMachineActiveStates> m_activeStates;
+        readonly DynamicBuffer<LayerWeights>                    m_layerWeights;
+        readonly DynamicBuffer<MecanimParameter>                m_parameters;
+        readonly DynamicBuffer<MecanimStateTransitionEvent>     m_stateTransitionEvents;
+        readonly DynamicBuffer<MecanimClipEvent>                m_clipEvents;
+
+        private DynamicBuffer<MecanimParameter> parameters => m_parameters;
+        private DynamicBuffer<LayerWeights> layerWeights => m_layerWeights;
+        private ref MecanimControllerBlob GetControllerBlob() => ref m_controller.ValueRO.controllerBlob.Value;
+
+        #region Controller
+        /// <summary>
+        /// Sets whether the animator controller state machine is enabled and allowed to update
+        /// </summary>
+        public bool enabled
+        {
+            get => m_controllerEnabled.ValueRO;
+            set => m_controllerEnabled.ValueRW = value;
+        }
+        
+        /// <summary>
+        /// The speed of the controller relative to normal Time.deltaTime
+        /// </summary>
+        public float speed
+        {
+            get => m_controller.ValueRO.speed;
+            set => m_controller.ValueRW.speed = value;
+        }
+        
+        
+        /// <summary>
+        /// Advances all state machines for this animation controller by deltaTime
+        /// </summary>
+        public void Update(OptimizedSkeletonAspect optimizedSkeletonAspect, double elapsedTime, float deltaTime)
+        {
+            var threadStackAllocator = ThreadStackAllocator.GetAllocator();
+            
+            MecanimUpdater.Update(
+                ref threadStackAllocator,
+                ref m_controller.ValueRW,
+                m_activeStates.AsNativeArray().AsSpan(),
+                m_layerWeights.AsNativeArray().AsReadOnlySpan(),
+                m_parameters.AsNativeArray().AsSpan(),
+                optimizedSkeletonAspect,
+                m_stateTransitionEvents,
+                m_clipEvents,
+                elapsedTime,
+                deltaTime);
+            
+            threadStackAllocator.Dispose();
+        }
+        
+        /// <summary>
+        /// Gets the weight of the given layer (slow)
+        /// </summary>
+        /// <param name="layerName">The layer name in the Mecanim Controller.</param>
+        /// <returns>The current weight for the layer.</returns>
+        public float GetLayerWeight(FixedString128Bytes layerName)
+        {
+            return GetLayerWeight(GetLayerIndex(layerName));
+        }
+        
+        /// <summary>
+        /// Gets the weight of the layer at the given index (fastest)
+        /// </summary>
+        /// <param name="index">The layer index in the Mecanim Controller's list of layers.</param>
+        /// <returns>The current weight for the layer.</returns>
+        public float GetLayerWeight(short index)
+        {
+            if (index < 0)
+            {
+                Debug.LogWarning($"Layer not found in Mecanim animation controller.");
+                return 0f;
+            }
+            return layerWeights.ElementAt(index).weight;
+        }
+        
+        
+        /// <summary>
+        /// Sets the weight of the layer at the given index (slow)
+        /// </summary>
+        /// <param name="layerName">The layer name in the Mecanim Controller.</param>
+        /// <param name="weight">The weight to set for the layer. </param>
+        public void SetLayerWeight(FixedString128Bytes layerName, float weight)
+        {
+            SetLayerWeight(GetLayerIndex(layerName), weight);
+        }
+        
+        /// <summary>
+        /// Sets the weight of the layer at the given index (fastest)
+        /// </summary>
+        /// <param name="index">The layer index in the Mecanim Controller's list of layers.</param>
+        /// <param name="weight">The weight to set for the layer. </param>
+        public void SetLayerWeight(short index, float weight)
+        {
+            if (index < 0)
+            {
+                Debug.LogWarning($"Layer not found in Mecanim animation controller.");
+                return;
+            }
+            if (weight < 0 || weight > 1)
+            {
+                Debug.LogWarning($"Layer weight must be between 0 and 1. It was {weight}.");
+                return;
+            }
+            layerWeights.ElementAt(index).weight = weight;
+        }
+        #endregion
+        
+        
+        #region StateHandles
+        
+        /**
+         * This is an expensive call. Please cache and re-use the result.
+         * fullStateName must include all parent state machines names separated by dots. Example: "MySubMachine.MyChildSubMachine.Jump"
+         */
+        public StateHandle GetStateHandle(FixedString128Bytes layerName, FixedString128Bytes fullStateName)
+        {
+            var stateMachineIndex = GetControllerBlob().GetStateMachineIndex(layerName);
+            var stateIndex = GetControllerBlob().GetStateIndex(stateMachineIndex, fullStateName);
+            return new StateHandle { StateMachineIndex = stateMachineIndex, StateIndex = stateIndex };
+        }
+        
+        /**
+         * This is an expensive method. Please cache and re-use the result.
+         * fullStateName must include all parent state machines names separated by dots and be hashed using GetHashCode()
+         * Example: "MySubMachine.MyChildSubMachine.Jump".GetHashCode()
+         */
+        public StateHandle GetStateHandle(FixedString128Bytes layerName, int fullStateNameHashCode)
+        {
+            var stateMachineIndex = GetControllerBlob().GetStateMachineIndex(layerName);
+            var stateIndex = GetControllerBlob().GetStateIndex(stateMachineIndex, fullStateNameHashCode);
+            return new StateHandle { StateMachineIndex = stateMachineIndex, StateIndex = stateIndex };
+        }
+        
+        #endregion
+        
+        #region Indices
+        
+        /**
+         * This is an expensive method. Please cache and re-use the result.
+         */
+        public short GetLayerIndex(FixedString128Bytes layerName) => GetControllerBlob().GetLayerIndex(layerName);
+        
+        /**
+         * This is an expensive method. Please cache and re-use the result.
+         */
+        public short GetParameterIndex(FixedString64Bytes parameterName) => GetControllerBlob().GetParameterIndex(parameterName);
+        public short GetParameterIndex(int parameterNameHashCode) => GetControllerBlob().GetParameterIndex(parameterNameHashCode);
+
+        #endregion
+        
+        
+        
+        #region Parameters
+        
+        
+        /// <summary>
+        /// Returns the value of the given float parameter.
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters. (fastest)</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public float GetFloatParameter(short index)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Float)) return 0f;
+            return parameters[index].floatParam;  
+        } 
+
+        /// <summary>
+        /// Returns the value of the given float parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public float GetFloatParameter(FixedString64Bytes name)
+        {
+            return GetFloatParameter(GetParameterIndex(name));
+        }
+        
+        /// <summary>
+        /// Sets the value of the float parameter at index (fastest)
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters.</param>
+        /// <param name="value">The value to set for the parameter. </param>
+        public void SetFloatParameter(short index, float value)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Float)) return;
+            parameters.ElementAt(index).floatParam = value;
+        } 
+
+        /// <summary>
+        /// Sets the value of the given float parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="value">The value to set for the parameter. </param>
+        public void SetFloatParameter(FixedString64Bytes name, float value)
+        {
+            SetFloatParameter(GetParameterIndex(name), value);
+        }
+
+        
+        /// <summary>
+        /// Returns the value of the given int parameter.
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters. (fastest)</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public int GetIntParameter(short index)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Int)) return 0;
+            return parameters[index].intParam;
+        } 
+
+        /// <summary>
+        /// Returns the value of the given int parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public int GetIntParameter(FixedString64Bytes name)
+        {
+            return GetIntParameter(GetParameterIndex(name));
+        }
+
+        /// <summary>
+        /// Sets the value of the int parameter at index (fastest)
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters.</param>
+        /// <param name="value">The value to set for the parameter. </param>
+        public void SetIntParameter(short index, int value)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Int)) return;
+            parameters.ElementAt(index).intParam = value;
+        } 
+
+        /// <summary>
+        /// Sets the value of the given int parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="value">The value to set for the parameter. </param>
+        public void SetIntParameter(FixedString64Bytes name, int value)
+        {
+            SetIntParameter(GetParameterIndex(name), value);
+        }
+        
+        
+        /// <summary>
+        /// Returns the value of the given bool parameter.
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters. (fastest)</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public bool GetBoolParameter(short index)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Bool)) return false;
+            return parameters[index].boolParam;
+        } 
+
+        /// <summary>
+        /// Returns the value of the given bool parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public bool GetBoolParameter(FixedString64Bytes name)
+        {
+            return GetBoolParameter(GetParameterIndex(name));
+        }
+
+        /// <summary>
+        /// Sets the value of the bool parameter at index (fastest)
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters.</param>
+        /// <param name="value">The value to set for the parameter. </param>
+        public void SetBoolParameter(short index, bool value)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Bool)) return;
+            parameters.ElementAt(index).boolParam = value;
+        } 
+
+        /// <summary>
+        /// Sets the value of the given bool parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <param name="value">The value to set for the parameter. </param>
+        public void SetBoolParameter(FixedString64Bytes name, bool value)
+        {
+            SetBoolParameter(GetParameterIndex(name), value);
+        }
+        
+        /// <summary>
+        /// Returns the value of the given trigger parameter.
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters. (fastest)</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public bool GetTriggerParameter(short index)
+        {
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Trigger)) return false;
+            return parameters[index].triggerParam;
+        } 
+
+        /// <summary>
+        /// Returns the value of the given trigger parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        /// <returns>
+        /// The value of the parameter.
+        /// </returns>
+        public bool GetTriggerParameter(FixedString64Bytes name)
+        {
+            return GetTriggerParameter(GetParameterIndex(name));
+        }
+        
+        /// <summary>
+        /// Sets the trigger parameter at index (fastest)
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters.</param>
+        public void SetTrigger(short index)
+        { 
+            SetTriggerValue(index, true);
+        } 
+
+        /// <summary>
+        /// Sets the given trigger parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        public void SetTrigger(FixedString64Bytes name)
+        {
+            SetTriggerValue(GetParameterIndex(name), true);
+        }
+        
+        /// <summary>
+        /// Clears the trigger parameter at index (fastest)
+        /// </summary>
+        /// <param name="index">The parameter index in the Mecanim controller's list of parameters.</param>
+        public void ClearTrigger(short index)
+        { 
+            SetTriggerValue(index, false);
+        } 
+
+        /// <summary>
+        /// Clears the given trigger parameter.
+        /// </summary>
+        /// <param name="name">The parameter name.</param>
+        public void ClearTrigger(FixedString64Bytes name)
+        {
+            SetTriggerValue(GetParameterIndex(name), false);
+        }
+        
+        private void SetTriggerValue(short index, bool value)
+        { 
+            if (!IsValidParameterOfType(index, MecanimControllerBlob.ParameterTypes.Type.Trigger)) return;
+            parameters.ElementAt(index).triggerParam = value;
+        } 
+        
+        
+        
+        private bool IsValidParameterOfType(short index, MecanimControllerBlob.ParameterTypes.Type parameterType)
+        {
+            if (index < 0)
+            {
+                Debug.LogError("The Mecanim parameter was not found.");
+                return false;
+            }
+            if (GetControllerBlob().parameterTypes[index] != parameterType)
+            {
+                Debug.LogError($"The Mecanim parameter at index {index} is not the expected type. It's a '{GetControllerBlob().parameterNames[index]}'");
+                return false;
+            }
+
+            return true;
+        }
+        #endregion
+    }
+    
+    public struct StateHandle
+    {
+        public short StateMachineIndex;
+        public short StateIndex;
+    }
+}

--- a/AddOns/MecanimV2/Components/MecanimAspect.cs.meta
+++ b/AddOns/MecanimV2/Components/MecanimAspect.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 994fb2166d444d658217bde0f10f289b
+timeCreated: 1742759354

--- a/AddOns/MecanimV2/Latios.MecanimV2.asmdef
+++ b/AddOns/MecanimV2/Latios.MecanimV2.asmdef
@@ -9,7 +9,8 @@
         "GUID:e0cd26848372d4e5c891c569017e11f1",
         "GUID:734d92eba21c94caba915361bd5ac177",
         "GUID:8819f35a0fc84499b990e90a4ca1911f",
-        "GUID:d8b63aba1907145bea998dd612889d6b"
+        "GUID:d8b63aba1907145bea998dd612889d6b",
+        "GUID:a5baed0c9693541a5bd947d336ec7659"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/AddOns/MecanimV2/Utilities/MecanimUpdater.cs
+++ b/AddOns/MecanimV2/Utilities/MecanimUpdater.cs
@@ -154,7 +154,7 @@ namespace Latios.MecanimV2
                                      bool isFirstUpdate)
         {
             ref var layer = ref blob.layers[layerIndex];
-
+            
             for (int i = 0; i < passages.Length; i++)
             {
                 blender.sampleSkeleton = !eventsOnly && (i + 1) == passages.Length;

--- a/AddOns/MecanimV2/Utilities/MecanimUpdater.cs
+++ b/AddOns/MecanimV2/Utilities/MecanimUpdater.cs
@@ -16,8 +16,8 @@ namespace Latios.MecanimV2
                                   ReadOnlySpan<LayerWeights>                                 layerWeights,
                                   Span<MecanimParameter>                                     parameters,
                                   OptimizedSkeletonAspect skeleton,
-                                  DynamicBuffer<EventComponents.MecanimStateTransitionEvent> transitionEvents,
-                                  DynamicBuffer<EventComponents.MecanimClipEvent>            clipEvents,
+                                  DynamicBuffer<MecanimStateTransitionEvent> transitionEvents,
+                                  DynamicBuffer<MecanimClipEvent>            clipEvents,
                                   double elapsedTime,
                                   float deltaTime,
                                   int maxStateMachineIterations = 32)
@@ -219,16 +219,16 @@ namespace Latios.MecanimV2
 
         struct MotionBlender : MotionEvaluation.IProcessor
         {
-            public BlobAssetReference<SkeletonClipSetBlob>         clips;
-            public BlobAssetReference<SkeletonBoneMaskSetBlob>     masks;
-            public BufferPoseBlender                               blender;
-            public RootMotionDeltaAccumulator                      rootMotion;
-            public DynamicBuffer<EventComponents.MecanimClipEvent> events;
-            public float                                           stateWeight;
-            public int                                             maskIndex;
-            public bool                                            sampleRoot;
-            public bool                                            sampleSkeleton;
-            public bool                                            includeStartEvents;
+            public BlobAssetReference<SkeletonClipSetBlob>     clips;
+            public BlobAssetReference<SkeletonBoneMaskSetBlob> masks;
+            public BufferPoseBlender                           blender;
+            public RootMotionDeltaAccumulator                  rootMotion;
+            public DynamicBuffer<MecanimClipEvent>             events;
+            public float                                       stateWeight;
+            public int                                         maskIndex;
+            public bool                                        sampleRoot;
+            public bool                                        sampleSkeleton;
+            public bool                                        includeStartEvents;
 
             public void Execute(in MotionEvaluation.ClipResult result)
             {

--- a/AddOns/MecanimV2/Utilities/MecanimV2Bootstrap.cs
+++ b/AddOns/MecanimV2/Utilities/MecanimV2Bootstrap.cs
@@ -1,4 +1,3 @@
-using Latios.Mecanim.AddOns.MecanimV2.Systems;
 using Unity.Entities;
 
 namespace Latios.MecanimV2


### PR DESCRIPTION
Added motion evaluation for single clips and Simple 1D trees. Supports mirroring animations but MotionUpdater is not using that yet.
Fixed layer weights baking so we always have the buffer present (we need it for MecanimAspect queries to work).