### PR TITLE
Fixes for blend trees at origin, large skeletons and bone mask sampling

### DIFF
--- a/AddOns/MecanimV2/Components/ControllerBlobs.cs
+++ b/AddOns/MecanimV2/Components/ControllerBlobs.cs
@@ -253,9 +253,9 @@ namespace Latios.MecanimV2
             public BlendTreeType    blendTreeType;
             public BlobArray<Child> children;
             public BlobArray<short> parameterIndices;  // Todo: Make two shorts and use Child.position to store parameters for direct blending?
-            // For freeform trees, sized by (childCount - 1)^2, z is 1 / lengthSq
+            // For freeform trees, sized by (childCount - 1)^2, z is 1 / lengthSq, and w is 2 / (length(childPositionI) + length(childPositionJ))
             // For simple directional, sized by childCount, x is atan2(childPosition), y at index 0 is the index of the center child if any (asint)
-            public BlobArray<float3> pipjs;
+            public BlobArray<float4> pipjs;
 
             public enum BlendTreeType
             {
@@ -308,60 +308,62 @@ namespace Latios.MecanimV2
 
             internal const float kFreeformDirectionalBias = 2f;
         }
-        
-        
+
         internal short GetLayerIndex(FixedString128Bytes layerName)
         {
             for (short i = 0; i < layers.Length; i++)
             {
-                if (layers[i].name.Equals(layerName)) return i;
+                if (layers[i].name.Equals(layerName))
+                    return i;
             }
             return -1;
         }
-        
+
         internal short GetStateMachineIndex(FixedString128Bytes layerName)
         {
             return layers[GetLayerIndex(layerName)].stateMachineIndex;
         }
-        
+
         internal short GetStateIndex(short stateMachineIndex, FixedString128Bytes fullStateName)
         {
             ref var stateMachine = ref stateMachines[stateMachineIndex];
-            
+
             for (short i = 0; i < stateMachine.stateNameHashes.Length; i++)
             {
-                if (fullStateName.Equals(stateMachine.stateNames[i])) return i;
+                if (fullStateName.Equals(stateMachine.stateNames[i]))
+                    return i;
             }
             return -1;
         }
-        
+
         internal short GetStateIndex(short stateMachineIndex, int fullStateNameHash)
         {
             ref var stateMachine = ref stateMachines[stateMachineIndex];
-            
+
             for (short i = 0; i < stateMachine.stateNameHashes.Length; i++)
             {
-                if (fullStateNameHash == stateMachine.stateNameHashes[i]) return i;
+                if (fullStateNameHash == stateMachine.stateNameHashes[i])
+                    return i;
             }
             return -1;
         }
-        
-        
-        
+
         internal short GetParameterIndex(FixedString64Bytes parameterName)
         {
             for (short i = 0; i < parameterNames.Length; i++)
             {
-                if (parameterName == parameterNames[i]) return i;
+                if (parameterName == parameterNames[i])
+                    return i;
             }
             return -1;
         }
-        
+
         internal short GetParameterIndex(int parameterNameHash)
         {
-            for (short  i = 0; i < parameterNameHashes.Length; i++)
+            for (short i = 0; i < parameterNameHashes.Length; i++)
             {
-                if (parameterNameHash == parameterNameHashes[i]) return i;
+                if (parameterNameHash == parameterNameHashes[i])
+                    return i;
             }
             return -1;
         }

--- a/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
+++ b/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
@@ -632,7 +632,7 @@ namespace Latios.MecanimV2.Authoring.Systems
 
             blendTreeBlob.blendTreeType = MecanimControllerBlob.BlendTree.FromUnityBlendTreeType(blendTree.blendType);
 
-            Span<short>                                 parameterIndices      = stackalloc short[blendTree.children.Length];
+            Span<short>                                 parameterIndices      = stackalloc short[math.max(2, blendTree.children.Length)];
             int parameterIndicesCount = 0;
             Span<MecanimControllerBlob.BlendTree.Child> children              = stackalloc MecanimControllerBlob.BlendTree.Child[blendTree.children.Length];
             int childCount            = 0;

--- a/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
+++ b/AddOns/MecanimV2/Systems/AnimationControllerSmartBlobberSystem.cs
@@ -726,21 +726,24 @@ namespace Latios.MecanimV2.Authoring.Systems
                     for (int j = i + 1; j < childCount; j++)
                     {
                         var pj   = childrenBuilder[j].position;
-                        float3 pipj = default;
+                        float4 pipj = default;
                         if (blendTreeBlob.blendTreeType == MecanimControllerBlob.BlendTree.BlendTreeType.FreeformDirectional2D)
                         {
                             var pjmag = math.length(pj);
                             pipj.x = (pjmag - pimag) / (0.5f * (pimag + pjmag));
                             var direction = LatiosMath.ComplexMul(pi, new float2(pj.x, -pj.y));
-                            pipj.y = MecanimControllerBlob.BlendTree.kFreeformDirectionalBias * math.atan2(direction.y, direction.x);
+                            var directionAtan = math.select(math.atan2(direction.y, direction.x), 0, pi.Equals(float2.zero) || pj.Equals(float2.zero));
+                            pipj.y = MecanimControllerBlob.BlendTree.kFreeformDirectionalBias * directionAtan;
+                            pipj.w = 1f / (0.5f * (pimag + pjmag));
                         }
                         else
                         {
                             pipj.xy = pj - pi;
+                            pipj.w  = 1f;
                         }
                         pipj.z                                                                   = 1f / math.lengthsq(pipj.xy);
                         pipjBuilder[MecanimControllerBlob.BlendTree.PipjIndex(i, j, childCount)] = pipj;
-                        pipjBuilder[MecanimControllerBlob.BlendTree.PipjIndex(j, i, childCount)] = pipj * new float3(-1f, -1f, 1f);
+                        pipjBuilder[MecanimControllerBlob.BlendTree.PipjIndex(j, i, childCount)] = pipj * new float4(-1f, -1f, 1f, 1f);
                     }
                 }
             }
@@ -750,7 +753,7 @@ namespace Latios.MecanimV2.Authoring.Systems
                 for (int i = 0; i < childCount; i++)
                 {
                     var pos = childrenBuilder[i].position;
-                    pipjBuilder[i] = new float3(math.atan2(pos.y, pos.x), 0f, 0f);
+                    pipjBuilder[i] = new float4(math.atan2(pos.y, pos.x), 0f, 0f, 0f);
                     if (pos.Equals(float2.zero))
                         pipjBuilder[0].y = math.asfloat(i);
                     else if (i == 0)

--- a/AddOns/MecanimV2/Utilities/MecanimUpdater.cs
+++ b/AddOns/MecanimV2/Utilities/MecanimUpdater.cs
@@ -144,7 +144,7 @@ namespace Latios.MecanimV2
                         for (int i = 0; i < maskCount; i++)
                             maskPtr[i] = 0ul;
                     }
-                    else if (layer.boneMaskIndex > 0)
+                    else if (layer.boneMaskIndex >= 0)
                     {
                         var layerMask = controller.boneMasksBlob.Value[layer.boneMaskIndex];
                         for (int i = 0; i < layerMask.Length; i++)
@@ -215,12 +215,13 @@ namespace Latios.MecanimV2
                             var bits = maskPtr[m];
                             for (int i = math.tzcnt(bits); i < 64; bits ^= 1ul << i, i = math.tzcnt(bits))
                             {
-                                var add          = sampleBuffer[i];
+                                int boneIndex = m * 64 + i;
+                                var add          = sampleBuffer[boneIndex];
                                 var position     = add.position * layerWeight;
                                 var rotation     = math.nlerp(quaternion.identity, add.rotation, layerWeight);
                                 var scaleStretch = math.lerp(1f, new float4(add.stretch, add.scale), layerWeight);
                                 add              = new TransformQvvs(position, rotation, scaleStretch.w, scaleStretch.xyz, math.asint(1f));
-                                mixBuffer[i]     = RootMotionTools.ConcatenateDeltas(mixBuffer[i], in add);
+                                mixBuffer[boneIndex]     = RootMotionTools.ConcatenateDeltas(mixBuffer[boneIndex], in add);
                             }
                         }
                     }
@@ -231,13 +232,14 @@ namespace Latios.MecanimV2
                             var bits = maskPtr[m];
                             for (int i = math.tzcnt(bits); i < 64; bits ^= 1ul << i, i = math.tzcnt(bits))
                             {
-                                var oldBone  = mixBuffer[i];
-                                var newBone  = sampleBuffer[i];
+                                int boneIndex = m * 64 + i;
+                                var oldBone  = mixBuffer[boneIndex];
+                                var newBone  = sampleBuffer[boneIndex];
                                 var position = math.lerp(oldBone.position, newBone.position, layerWeight);
                                 var rotation = math.nlerp(oldBone.rotation, newBone.rotation, layerWeight);
                                 var scale    = math.lerp(oldBone.scale, newBone.scale, layerWeight);
                                 var stretch  = math.lerp(oldBone.stretch, newBone.stretch, layerWeight);
-                                mixBuffer[i] = new TransformQvvs(position, rotation, scale, stretch, math.asint(1f));
+                                mixBuffer[boneIndex] = new TransformQvvs(position, rotation, scale, stretch, math.asint(1f));
                             }
                         }
                     }

--- a/AddOns/MecanimV2/Utilities/MotionEvaluation.cs
+++ b/AddOns/MecanimV2/Utilities/MotionEvaluation.cs
@@ -676,9 +676,10 @@ namespace Latios.MecanimV2
                 {
                     var pmag      = math.length(p);
                     var pimag     = math.length(pi);
-                    pip.x         = (pmag - pimag) / math.max(0.5f * (pmag + pimag), math.EPSILON);
+                    pip.x         = pmag - pimag;
                     var direction = LatiosMath.ComplexMul(pi, new float2(p.x, -p.y));
-                    pip.y         = MecanimControllerBlob.BlendTree.kFreeformDirectionalBias * math.atan2(direction.y, direction.x);
+                    var directionAtan = math.select(math.atan2(direction.y, direction.x), 0, pi.Equals(float2.zero));
+                    pip.y         = MecanimControllerBlob.BlendTree.kFreeformDirectionalBias * directionAtan;
                 }
                 else
                 {
@@ -690,9 +691,12 @@ namespace Latios.MecanimV2
                 {
                     if (i == j)
                         continue;
-                    var pipj   = tree.pipjs[MecanimControllerBlob.BlendTree.PipjIndex(i, j, childCount)];
-                    var h      = math.max(0f, 1f - math.dot(pip, pipj.xy) * pipj.z);
-                    weights[i] = math.min(weights[i], h);
+
+                    var pipj    = tree.pipjs[MecanimControllerBlob.BlendTree.PipjIndex(i, j, childCount)];
+                    var pipp    = pip;
+                    pipp.x     *= pipj.w;
+                    var h       = math.max(0f, 1f - math.dot(pipp, pipj.xy) * pipj.z);
+                    weights[i]  = math.min(weights[i], h);
                 }
 
                 accumulatedWeight += weights[i];


### PR DESCRIPTION
Fixing 2D Freeform blend tree weight calculations for clips at origin. 
Fixing bone sampling for large skeletons with over 64 bones in multi-layer animation controllers.
Fixing first layer mask not being applied.