### PR TITLE
Adding manually triggered inertial blends. Fixing root motion issues with variable DeltaTime

### DIFF
--- a/AddOns/MecanimV2/Components/ControllerComponents.cs
+++ b/AddOns/MecanimV2/Components/ControllerComponents.cs
@@ -19,10 +19,23 @@ namespace Latios.Mecanim
         /// </summary>
         public float realtimeInInertialBlend;
         /// <summary>
-        /// Determined if root motion should be applied to the root bone automatically
+        /// Duration of a manually triggered inertial blend. -1f if no manual inertial blending is happening or once the inertial blend already started.
+        /// </summary>
+        public float manualInertialBlendDurationSeconds;
+        /// <summary>
+        /// Determines if a manual inertial blend is being performed.
+        /// </summary>
+        public bool performingManualInertialBlend;
+        
+        /// <summary>
+        /// Determines if root motion should be applied to the root bone automatically
         /// </summary>
         public bool applyRootMotion;
-        
+
+        public void StartInertialBlend(float durationSeconds)
+        {
+            manualInertialBlendDurationSeconds = durationSeconds;
+        }
     }
 
     /// <summary>

--- a/AddOns/MecanimV2/Components/MecanimAspect.cs
+++ b/AddOns/MecanimV2/Components/MecanimAspect.cs
@@ -400,6 +400,17 @@ namespace Latios.Mecanim
             return true;
         }
         #endregion
+
+        /// <summary>
+        /// Orders Mecanim to start a new inertial blend of the given duration
+        /// </summary>
+        /// <param name="durationSeconds">Total duration of the inertial blend (in seconds).</param>
+        #region Inertial Blend
+        public void StartInertialBlend(float durationSeconds)
+        {
+            m_controller.ValueRW.StartInertialBlend(durationSeconds);
+        }
+        #endregion
     }
 
     public struct StateHandle

--- a/AddOns/MecanimV2/Utilities/MathUtil.cs
+++ b/AddOns/MecanimV2/Utilities/MathUtil.cs
@@ -1,0 +1,26 @@
+﻿using Unity.Mathematics;
+
+namespace Latios.Mecanim
+{
+    public class MathUtil
+    {
+        /**
+         * Scales a quaternion by a float using angle-axis approach
+         */
+        public static quaternion ScaleQuaternion(quaternion transformQvvsRotation, float scale)
+        {
+            transformQvvsRotation = math.normalize(transformQvvsRotation);
+
+            float halfAngle = math.acos(transformQvvsRotation.value.w);
+            float angle = halfAngle * 2f;
+            
+            float sinHalf = math.sin(halfAngle);
+            float3 axis = (sinHalf > 1e-6f) 
+                ? transformQvvsRotation.value.xyz / sinHalf
+                : new float3(0f,0f,1f); // fallback axis
+            
+            quaternion scaledQuaternion = quaternion.AxisAngle(axis, angle * scale);
+            return scaledQuaternion;
+        }
+    }
+}

--- a/AddOns/MecanimV2/Utilities/MathUtil.cs.meta
+++ b/AddOns/MecanimV2/Utilities/MathUtil.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 056150f269634577ab5ef3678fa7f951
+timeCreated: 1745873606


### PR DESCRIPTION
Allowing users to manually trigger inertial blends.
Fixing root motion issues when DeltaTime is variable (normal variations or slow motion and pause). Now we store the root motion transforms without DeltaTime scaling, and then apply delta scaling when applying the root motion in our system.