### PR TITLE
[Anna] Add support for overriding RB center of mass and inertia

### DIFF
--- a/AddOns/Anna/Components/RigidBodyComponents.cs
+++ b/AddOns/Anna/Components/RigidBodyComponents.cs
@@ -1,7 +1,5 @@
 using Latios.Psyshock;
-using Unity.Collections;
 using Unity.Entities;
-using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace Latios.Anna
@@ -40,5 +38,14 @@ namespace Latios.Anna
             impulse.z   = float.NaN;
         }
     }
-}
 
+    public struct LocalCenterOfMassOverride : IComponentData
+    {
+        public float3 centerOfMass;
+    }
+
+    public struct LocalInertiaOverride : IComponentData
+    {
+        public UnitySim.LocalInertiaTensorDiagonal inertiaDiagonal;
+    }
+}


### PR DESCRIPTION
Adds new Rigid Body components to let Anna users provide manual overrides to the center of mass and inertia diagonal of a Rigid Body.
