### PR TITLE
Anna Gravity Overrides

### DIFF
--- a/AddOns/Anna/Authoring/AnnaRigidBodyAuthoring.cs
+++ b/AddOns/Anna/Authoring/AnnaRigidBodyAuthoring.cs
@@ -29,9 +29,6 @@ namespace Latios.Anna.Authoring
 
         [Header("Custom Gravity Properties")]
         public float3 gravityOverride    = new float3(0f, -9.81f, 0f);
-        public float3 gravityScale       = new float3(0f, 1f, 0f);
-
-
     }
 
     public class AnnaRigidBodyAuthoringBaker : Baker<AnnaRigidBodyAuthoring>
@@ -66,7 +63,6 @@ namespace Latios.Anna.Authoring
             if (authoring.supportCustomGravity)
             {
                 AddComponent(entity, new GravityOverride {
-                    scale = authoring.gravityScale,
                     gravity = authoring.gravityOverride
                 });
             }

--- a/AddOns/Anna/Components/RigidBodyComponents.cs
+++ b/AddOns/Anna/Components/RigidBodyComponents.cs
@@ -53,6 +53,5 @@ namespace Latios.Anna
     public struct GravityOverride : IComponentData
     {
         public float3 gravity;
-        public float3 scale;
     }
 }

--- a/AddOns/Anna/Systems/CollectRigidBodiesSystem.cs
+++ b/AddOns/Anna/Systems/CollectRigidBodiesSystem.cs
@@ -132,7 +132,7 @@ namespace Latios.Anna.Systems
                                                        out var inertialPoseWorldTransform);
 
 
-                    float3 gravity = gravityOverrides == null ? physicsSettings.gravity : gravityOverrides[i].gravity * gravityOverrides[i].scale;
+                    float3 gravity = gravityOverrides == null ? physicsSettings.gravity : gravityOverrides[i].gravity;
                     
                     rigidBody.velocity.linear += gravity * dt;
 


### PR DESCRIPTION
## Contribution Standard Info

## Details

Anna can now override the global PhysicsSettings gravity value for individual rigidbodies. This option can be set using AnnaRigidBodyAuthoring in the inspector or the GravityOverride component can be added to an entity with an Anna RigidBody.

This opens the door for mechanics where individual objects may be affected by gravity independent of the engine settings.
